### PR TITLE
feat: Implement merkle tree data import and verification

### DIFF
--- a/merkle/bot/README.zh-CN.md
+++ b/merkle/bot/README.zh-CN.md
@@ -1,0 +1,48 @@
+# **🤖 Slackbot 使用流程**
+
+本节概述了使用 Slackbot 分发奖励的标准程序。
+
+1.  **将 JSON 转换为 CSV**
+    -   使用 `convert` 命令并附上包含投票权重数据的 JSON 文件。
+    -   机器人会将数据转换为 CSV 格式 (`address,amount`)。
+    -   **注意：** JSON 文件可以包含多个周期的数据。`--epoch` 标志用于指定要处理哪一个周期的数据。
+    -   **命令：** `@<bot_name> convert --epoch <epoch_number> --total_amount <amount>`
+
+2.  **整合未领取的奖励**
+    -   使用 `export_airdrop` 命令并附上步骤 1 中生成的 CSV 文件。
+    -   此命令会先通过与链上数据同步，来更新前一个周期 (`epoch - 1`) 的领取状态。然后，它会将新的分发金额与前一个周期未领取的奖励整合。最后输出一个新的、整合后的 CSV 文件。
+    -   **注意：** `--epoch` 标志代表新的周期，因此应设置为 `Airdrop` 合约中的 `currentEpoch` + 1。
+    -   **命令：** `@<bot_name> export_airdrop --epoch <epoch_number>`
+
+3.  **导入数据**
+    -   仔细验证步骤 2 中 CSV 文件的数据。
+    -   确认无误后，使用 `import` 命令并附上已验证的 CSV 文件。这会将空投数据写入新周期的数据，并同时创建用于验证的默克尔树信息。
+    -   **注意：** `--epoch` 标志代表新的周期，因此应设置为 `Airdrop` 合约中的 `currentEpoch` + 1。
+    -   **命令：** `@<bot_name> import --epoch <epoch_number>`
+
+4.  **验证数据完整性**
+    -   最后，执行 `merkletree` 命令，对数据库中的数据完整性进行最终验证。
+    -   **命令：** `@<bot_name> merkletree --epoch <epoch_number> --address <address>`
+
+---
+
+### **查询空投信息**
+
+使用 `airdrop_info` 命令来获取空投合约的即时链上信息。此命令会显示：
+-   当前的空投周期。
+-   空投目前是否处于活跃状态。
+-   空投合约的 BR 代币余额。
+-   空投合约的地址。
+
+这对于监控合约的状态和余额非常有用。
+
+-   **命令：** `@<bot_name> airdrop_info`
+
+---
+
+### **还原导入操作**
+
+如果您导入数据后发现有误，可以使用 `revert` 命令。此命令将删除指定周期的空投数据和默克尔树信息，以便您重新导入修正后的数据。
+
+-   **重要提示：** 您只能还原尚未在链上设定的周期。目标周期必须是合约中 `currentEpoch` + 1。
+-   **命令：** `@<bot_name> revert --epoch <epoch_number>`

--- a/merkle/bot/README.zh-TW.md
+++ b/merkle/bot/README.zh-TW.md
@@ -1,0 +1,48 @@
+# **🤖 Slackbot 使用流程**
+
+本節概述了使用 Slackbot 分發獎勵的標準程序。
+
+1.  **將 JSON 轉換為 CSV**
+    -   使用 `convert` 指令並附上包含投票權重數據的 JSON 檔案。
+    -   機器人會將數據轉換為 CSV 格式 (`address,amount`)。
+    -   **注意：** JSON 檔案可以包含多個週期的數據。`--epoch` 旗標用於指定要處理哪一個週期的數據。
+    -   **指令：** `@<bot_name> convert --epoch <epoch_number> --total_amount <amount>`
+
+2.  **整合未領取的獎勵**
+    -   使用 `export_airdrop` 指令並附上步驟 1 中產生的 CSV 檔案。
+    -   此指令會先透過與鏈上數據同步，來更新前一個週期 (`epoch - 1`) 的領取狀態。然後，它會將新的分發金額與前一個週期未領取的獎勵整合。最後輸岀一個新的、整合後的 CSV 檔案。
+    -   **注意：** `--epoch` 旗標代表新的週期，因此應設定為 `Airdrop` 合約中的 `currentEpoch` + 1。
+    -   **指令：** `@<bot_name> export_airdrop --epoch <epoch_number>`
+
+3.  **匯入資料**
+    -   仔細驗證步驟 2 中 CSV 檔案的數據。
+    -   確認無誤後，使用 `import` 指令並附上已驗證的 CSV 檔案。這會將空投數據寫入新週期的資料庫，並同時建立用於驗證的默克爾樹資訊。
+    -   **注意：** `--epoch` 旗標代表新的週期，因此應設定為 `Airdrop` 合約中的 `currentEpoch` + 1。
+    -   **指令：** `@<bot_name> import --epoch <epoch_number>`
+
+4.  **驗證資料完整性**
+    -   最後，執行 `merkletree` 指令，對資料庫中的數據完整性進行最終驗證。
+    -   **指令：** `@<bot_name> merkletree --epoch <epoch_number> --address <address>`
+
+---
+
+### **查詢空投資訊**
+
+使用 `airdrop_info` 指令來獲取空投合約的即時鏈上資訊。此指令會顯示：
+-   當前的空投週期。
+-   空投目前是否處於活躍狀態。
+-   空投合約的 BR 代幣餘額。
+-   空投合約的地址。
+
+這對於監控合約的狀態和餘額非常有用。
+
+-   **指令：** `@<bot_name> airdrop_info`
+
+---
+
+### **還原匯入操作**
+
+如果您匯入數據後發現有誤，可以使用 `revert` 指令。此指令將刪除指定週期的空投數據和默克爾樹資訊，讓您可以重新匯入修正後的數據。
+
+-   **重要提示：** 您只能還原尚未在鏈上設定的週期。目標週期必須是合約中 `currentEpoch` + 1。
+-   **指令：** `@<bot_name> revert --epoch <epoch_number>`

--- a/merkle/bot/cmd/cmd_import.go
+++ b/merkle/bot/cmd/cmd_import.go
@@ -36,7 +36,6 @@ func NewImportCommand() Command {
 		Usage: `Calculates the Merkle root from a CSV file.
 
 *Flags:*
-  --update: Update existing data. If not provided, new data will be imported.
   --epoch <number>: (Required) The epoch to process.`,
 		Execute: runImportCommand,
 	}
@@ -47,7 +46,6 @@ func runImportCommand(ctx CommandContext) (string, error) {
 	importFlagSet := flag.NewFlagSet("import", flag.ContinueOnError)
 
 	// 2. Define the flags.
-	updateFlag := importFlagSet.Bool("update", false, "Update latest merkle root. If not provided, new data will be imported.")
 	epoch := importFlagSet.Uint64("epoch", math.MaxUint64, "The epoch to process (required).")
 
 	// 3. Parse the arguments.
@@ -78,9 +76,8 @@ func runImportCommand(ctx CommandContext) (string, error) {
 
 	// Use a goroutine for the heavy lifting.
 	args := processImportArgs{
-		file:   *csvFile,
-		update: *updateFlag,
-		epoch:  *epoch,
+		file:  *csvFile,
+		epoch: *epoch,
 	}
 	go processImport(ctx, args)
 
@@ -89,9 +86,8 @@ func runImportCommand(ctx CommandContext) (string, error) {
 
 // processImport handles the downloading, processing, and posting the result.
 type processImportArgs struct {
-	file   slack.File
-	update bool
-	epoch  uint64
+	file  slack.File
+	epoch uint64
 }
 
 func processImport(ctx CommandContext, args processImportArgs) {
@@ -146,12 +142,7 @@ func processImport(ctx CommandContext, args processImportArgs) {
 	}
 
 	// 3. Dispatch to the correct handler
-	var handlerErr error
-	if args.update {
-		handlerErr = handleUpdate(ctx, merkleTree, args.epoch)
-	} else {
-		handlerErr = handleImport(ctx, merkleTree, args.epoch)
-	}
+	handlerErr := handleImport(ctx, merkleTree, args.epoch)
 
 	if handlerErr != nil {
 		slog.Error("Error processing merkletree", "error", handlerErr, "channel", channelID)
@@ -163,15 +154,6 @@ func processImport(ctx CommandContext, args processImportArgs) {
 	hexMerkleRoot := hexutil.Encode(merkleRoot)
 
 	postMessage(ctx.Client, channelID, "Merkle root successfully calculated: "+hexMerkleRoot, timestamp, MessageTypeInfo)
-}
-
-func handleUpdate(ctx CommandContext, merkleTree *MerkleTree, epoch uint64) error {
-	if err := MerkleTreeManager.Update(merkleTree, epoch); err != nil {
-		return err
-	}
-
-	slog.Info("Successfully calculated Merkle root for update", "channel", ctx.AppMentionEvent.Channel, "epoch", epoch)
-	return nil
 }
 
 func handleImport(ctx CommandContext, merkleTree *MerkleTree, epoch uint64) error {

--- a/merkle/bot/cmd/merkle_tree_mgr.go
+++ b/merkle/bot/cmd/merkle_tree_mgr.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -136,10 +137,27 @@ func (m *merkleTreeManager) Import(merkleTree *MerkleTree, epoch uint64) error {
 	airdropRecords := make([]*psql.AirdropData, 0, len(merkleTree.Address))
 
 	for addr := range merkleTree.Address {
+		leaf := []any{
+			merkletree.SolAddress(addr),
+			merkletree.SolNumber(merkleTree.Amount[addr].String()),
+		}
+
+		proof, err := merkleTree.Tree.GetProof(leaf)
+		if err != nil {
+			return fmt.Errorf("failed to get proof for address %s: %v", addr, err)
+		}
+
+		// Convert proof to hex strings
+		hexProof := make([]string, len(proof))
+		for i, p := range proof {
+			hexProof[i] = "0x" + hex.EncodeToString(p)
+		}
+
 		airdropRecords = append(airdropRecords, &psql.AirdropData{
 			Epoch:     epoch,
 			Address:   addr,
 			Amount:    merkleTree.Amount[addr].String(),
+			Proof:     hexProof,
 			Claimed:   false,
 			CreatedAt: time.Now().Unix(),
 		})

--- a/merkle/bot/cmd/merkle_tree_mgr.go
+++ b/merkle/bot/cmd/merkle_tree_mgr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/Bedrock-Technology/VeMerkle/internal/contracts"
@@ -29,27 +30,33 @@ func MerkleTreeManagerInit() {
 	}
 
 	if maxEpoch == 0 {
-		slog.Error("No Merkle tree found in database")
+		slog.Info("No Merkle tree found in database, initializing empty manager")
 		MerkleTreeManager = mgr
 		return
 	}
 
 	// If maxEpoch is greater than 0, it means there's a Merkle tree to load
-	slog.Info("Loading latest Merkle tree into memory")
+	slog.Info("Loading latest Merkle tree into memory", slog.Uint64("epoch", maxEpoch))
 	// Use the Get method to load the Merkle tree, which handles both
 	// database retrieval and in-memory caching.
 	if _, err := mgr.Get(maxEpoch); err != nil {
 		slog.Error("Failed to load Merkle tree for the latest epoch", slog.Uint64("epoch", maxEpoch), slog.Any("error", err))
+		panic(err)
 	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
 
 	mgr.maxEpoch = maxEpoch
 	MerkleTreeManager = mgr
+	slog.Info("[MerkleTreeManager] Initialized successfully", slog.Uint64("max_epoch", maxEpoch))
 }
 
 // MerkleTreeManager is a type alias for a map that manages MerkleTree instances by epoch.
 type merkleTreeManager struct {
 	trees    map[uint64]*MerkleTree
 	maxEpoch uint64
+	mu       sync.Mutex
 }
 
 // MerkleTree holds the standard Merkle tree, along with maps for quick address and amount lookups.
@@ -163,6 +170,7 @@ func (m *merkleTreeManager) Import(merkleTree *MerkleTree, epoch uint64) error {
 		})
 	}
 
+	merkleTree.Epoch = epoch
 	// Marshal the Merkle tree
 	marshaledData, err := json.Marshal(merkleTree)
 	if err != nil {
@@ -174,7 +182,12 @@ func (m *merkleTreeManager) Import(merkleTree *MerkleTree, epoch uint64) error {
 		return fmt.Errorf("failed to save airdrop and merkle tree data: %v", err)
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.trees[epoch] = merkleTree
+	slog.Info("[MerkleTreeManager] Import", slog.Uint64("max_epoch", epoch))
+
 	m.maxEpoch = epoch
 	return nil
 }
@@ -204,6 +217,9 @@ func (m *merkleTreeManager) Update(merkleTree *MerkleTree, epoch uint64) error {
 		return fmt.Errorf("epoch does not exist in database")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.trees[epoch] = merkleTree
 	return nil
 }
@@ -230,8 +246,13 @@ func (m *merkleTreeManager) Delete(epoch uint64) error {
 		return fmt.Errorf("failed to delete airdrop and merkle tree data from database: %v", err)
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	// Delete from memory
 	delete(m.trees, epoch)
+	slog.Info("[MerkleTreeManager] Delete", slog.Uint64("max_epoch", epoch-1))
+
 	m.maxEpoch = epoch - 1
 	return nil
 }
@@ -241,7 +262,9 @@ func (m *merkleTreeManager) Delete(epoch uint64) error {
 // database for the marshaled tree data, unmarshals it, and stores it in memory
 // for future access before returning it.
 func (m *merkleTreeManager) Get(epoch uint64) (*MerkleTree, error) {
+	m.mu.Lock()
 	tree, found := m.trees[epoch]
+	m.mu.Unlock()
 	if found {
 		return tree, nil
 	}
@@ -259,6 +282,14 @@ func (m *merkleTreeManager) Get(epoch uint64) (*MerkleTree, error) {
 
 	merkleTree.Epoch = epoch
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check again in case another goroutine loaded the tree while we were working
+	if existingTree, ok := m.trees[epoch]; ok {
+		return existingTree, nil
+	}
+
 	// Store in memory for future access
 	m.trees[epoch] = &merkleTree
 
@@ -267,8 +298,12 @@ func (m *merkleTreeManager) Get(epoch uint64) (*MerkleTree, error) {
 
 // GetLatestMerkleTree retrieves the Merkle tree for the highest epoch.
 func (m *merkleTreeManager) GetLatestMerkleTree() (*MerkleTree, error) {
-	if m.maxEpoch == 0 {
+	m.mu.Lock()
+	maxEpoch := m.maxEpoch
+	m.mu.Unlock()
+
+	if maxEpoch == 0 {
 		return nil, fmt.Errorf("no merkle tree found in manager")
 	}
-	return m.Get(m.maxEpoch)
+	return m.Get(maxEpoch)
 }

--- a/merkle/cmd/run.go
+++ b/merkle/cmd/run.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/csv"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -195,65 +194,20 @@ func getMerkleProof(c *gin.Context) {
 		return
 	}
 
-	// Check if address exists
-	index, exists := merkleDB.Address[address]
-	if !exists {
-		logrus.WithField("address", request.Address).Warn("Address not found")
+	// Query database for airdrop data
+	airdropData, err := database.GetAirdropDataByEpochAndAddress(merkleDB.Epoch, address)
+	if err != nil {
+		logrus.WithField("address", request.Address).WithError(err).Warn("Address not found in database for current epoch")
 		proto.ErrorMsg(c, "address not found")
 		return
 	}
-	logrus.WithFields(logrus.Fields{
-		"query address": address,
-		"in array indx": index,
-	}).Info("Reading merkle db")
-
-	// Get amount and proof
-	amount := merkleDB.Amount[address]
-	leaf := []interface{}{
-		smt.SolAddress(address),
-		smt.SolNumber(amount.String()),
-	}
-
-	proof, err := merkleDB.Tree.GetProof(leaf)
-	if err != nil {
-		logrus.WithError(err).Error("Failed to get Merkle proof")
-		proto.ErrorMsg(c, "failed to get Merkle proof")
-		return
-	}
-
-	// Verify the proof
-	verify, err := merkleDB.Tree.Verify(proof, leaf)
-	if err != nil {
-		logrus.WithError(err).Error("Failed to verify Merkle proof")
-		proto.ErrorMsg(c, "failed to verify Merkle proof")
-		return
-	}
-	if !verify {
-		logrus.WithFields(logrus.Fields{
-			"address": address,
-			"amount":  amount.String(),
-		}).Error("Invalid Merkle proof generated")
-		proto.ErrorMsg(c, "invalid merkle proof")
-		return
-	}
-
-	// Convert proof to hex strings
-	hexProof := make([]string, len(proof))
-	for i, p := range proof {
-		hexProof[i] = "0x" + hex.EncodeToString(p)
-	}
-
-	logrus.WithFields(logrus.Fields{
-		"address": address,
-		"amount":  amount.String(),
-	}).Info("Generated Merkle proof")
 
 	treeRoot := hexutil.Encode(merkleDB.Tree.GetRoot())
 	proto.SuccessMsg(c, http.StatusOK, "Merkle proof generated successfully", gin.H{
 		"epoch":   merkleDB.Epoch,
 		"address": address,
-		"amount":  amount.String(),
-		"proof":   hexProof,
+		"amount":  merkleDB.Amount[address].String(),
+		"proof":   airdropData.Proof,
 		"root":    treeRoot,
 	})
 }

--- a/merkle/go.mod
+++ b/merkle/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jszwec/csvutil v1.10.0
+	github.com/lib/pq v1.10.9
 	github.com/samber/slog-logrus/v2 v2.5.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.17.3

--- a/merkle/go.sum
+++ b/merkle/go.sum
@@ -171,6 +171,8 @@ github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzW
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=

--- a/merkle/internal/database/provider.go
+++ b/merkle/internal/database/provider.go
@@ -179,6 +179,20 @@ func GetClaimedAirdropDataByEpoch(epoch uint64, claimed bool) ([]*psql.AirdropDa
 	return records, nil
 }
 
+// GetAirdropDataByEpochAndAddress retrieves airdrop data for a specific epoch and address
+func GetAirdropDataByEpochAndAddress(epoch uint64, address string) (*psql.AirdropData, error) {
+	db, err := GetDBConnection("postgres")
+	if err != nil {
+		return nil, err
+	}
+
+	var airdrop psql.AirdropData
+	if err := db.Where("epoch = ? AND address = ?", epoch, address).First(&airdrop).Error; err != nil {
+		return nil, err
+	}
+	return &airdrop, nil
+}
+
 // DeleteAirdropDataByEpoch deletes all airdrop data for a specific epoch
 func DeleteAirdropDataByEpoch(epoch uint64) error {
 	db, err := GetDBConnection("postgres")

--- a/merkle/internal/database/psql/model.go
+++ b/merkle/internal/database/psql/model.go
@@ -1,5 +1,7 @@
 package psql
 
+import "github.com/lib/pq"
+
 type AirdropData struct {
 	ID        int64  `gorm:"primary_key" json:"id"`
 	CreatedAt int64  `gorm:"not null;default:0" json:"createdAt"`
@@ -7,7 +9,11 @@ type AirdropData struct {
 	Epoch     uint64 `gorm:"not null;default:0;index:idx_epoch_user" json:"epoch"`
 	Address   string `gorm:"not null;index:idx_epoch_user" json:"address"`
 	Amount    string `gorm:"type:numeric(78,0);not null" json:"amount"`
-	Claimed   bool   `gorm:"not null;default:false" json:"claimed"`
+	// Proof must be of type pq.StringArray, not []string.
+	// Although the underlying type is []string, pq.StringArray provides the necessary interface
+	// for GORM to correctly translate the data into a SQL statement for PostgreSQL array types.
+	Proof   pq.StringArray `gorm:"type:text[];default:'{}'" json:"proof"`
+	Claimed bool           `gorm:"not null;default:false" json:"claimed"`
 }
 
 type MerkleTreeData struct {


### PR DESCRIPTION
This commit introduces the functionality to import and verify Merkle tree data for airdrops. It includes:

- Adds commands for importing airdrop data from CSV files and generating Merkle trees.
- Implements data integrity verification using the `merkletree` command.
- Introduces a `revert` command to revert import operations.
- Adds Chinese translation documents.
- Removes the update flag from the import command.